### PR TITLE
ML-700: Limit Language Detection Prediction to Only Given Languages

### DIFF
--- a/langdetect/detector_factory.py
+++ b/langdetect/detector_factory.py
@@ -19,8 +19,11 @@ class DetectorFactory(object):
     This class manages an initialization and constructions of Detector.
 
     Before using language detection library,
-    load profiles with DetectorFactory.load_profile(str)
+    load profiles with DetectorFactory.load_profile(str, list)
     and set initialization parameters.
+
+    You could also specify the pool of languages to make predictions
+    from by specifying supported_languages.
 
     When the language detection,
     construct Detector instance via DetectorFactory.create().
@@ -32,8 +35,9 @@ class DetectorFactory(object):
         self.word_lang_prob_map = {}
         self.langlist = []
 
-    def load_profile(self, profile_directory):
-        list_files = os.listdir(profile_directory)
+    def load_profile(self, profile_directory, supported_languages=[]):
+        list_files = supported_languages if supported_languages else os.listdir(profile_directory)
+
         if not list_files:
             raise LangDetectException(ErrorCode.NeedLoadProfileError, 'Not found profile: ' + profile_directory)
 
@@ -116,22 +120,26 @@ class DetectorFactory(object):
 
 PROFILES_DIRECTORY = path.join(path.dirname(__file__), 'profiles')
 _factory = None
+_supported_languages = []
 
-def init_factory():
+def init_factory(supported_languages=[]):
     global _factory
-    if _factory is None:
-        _factory = DetectorFactory()
-        _factory.load_profile(PROFILES_DIRECTORY)
+    global _supported_languages
 
-def detect(text):
-    init_factory()
+    if _factory is None or _supported_languages != supported_languages:
+        _supported_languages = supported_languages
+        _factory = DetectorFactory()
+        _factory.load_profile(PROFILES_DIRECTORY, _supported_languages)
+
+def detect(text, supported_languages=[]):
+    init_factory(supported_languages=supported_languages)
     detector = _factory.create()
     detector.append(text)
     return detector.detect()
 
 
-def detect_langs(text):
-    init_factory()
+def detect_langs(text, supported_languages=[]):
+    init_factory(supported_languages=supported_languages)
     detector = _factory.create()
     detector.append(text)
     return detector.get_probabilities()

--- a/langdetect/detector_factory.py
+++ b/langdetect/detector_factory.py
@@ -35,7 +35,15 @@ class DetectorFactory(object):
         self.word_lang_prob_map = {}
         self.langlist = []
 
-    def load_profile(self, profile_directory, supported_languages=[]):
+    def load_profile(self, profile_directory, supported_languages=None):
+        """
+        Loads language profiles from the given directory.
+
+        Args:
+            profile_directory: path to the language profiles
+            supported_languages: set of languages from which the predictions will be made;
+            The languages should be in ISO 639-1 format (eg: "fr", "en", "de" and so on)
+        """
         list_files = supported_languages if supported_languages else os.listdir(profile_directory)
 
         if not list_files:
@@ -120,9 +128,9 @@ class DetectorFactory(object):
 
 PROFILES_DIRECTORY = path.join(path.dirname(__file__), 'profiles')
 _factory = None
-_supported_languages = []
+_supported_languages = None
 
-def init_factory(supported_languages=[]):
+def init_factory(supported_languages=None):
     global _factory
     global _supported_languages
 
@@ -131,15 +139,17 @@ def init_factory(supported_languages=[]):
         _factory = DetectorFactory()
         _factory.load_profile(PROFILES_DIRECTORY, _supported_languages)
 
-def detect(text, supported_languages=[]):
+def detect(text, supported_languages=None):
     init_factory(supported_languages=supported_languages)
     detector = _factory.create()
     detector.append(text)
+
     return detector.detect()
 
 
-def detect_langs(text, supported_languages=[]):
+def detect_langs(text, supported_languages=None):
     init_factory(supported_languages=supported_languages)
     detector = _factory.create()
     detector.append(text)
+
     return detector.get_probabilities()


### PR DESCRIPTION
### Why was this PR opened? ###
JIRA stories:
https://adasupport.atlassian.net/browse/ML-700

At the moment, the language detector predicts whether a givens sentences is one of 25 languages supported by Ada. This PR limits the languages predicted to only languages supported by the specific bot.

### What are the changes? ###
- restrict the predictions to input languages

### How can someone test the changes? ###
```python
>>>from langdetect import detect_langs
>> detect_langs("Jag har gjort uttag för 1dag sedan men pengar kommer inte fram till min konto")
[sv:0.9999987120106826]
>>>detect_langs("Jag har gjort uttag för 1dag sedan men pengar kommer inte fram till min konto", supported_languages=["en", "no", "hi"])
[no:0.9999979589883876]
```
should now give you `zh-tw` as the output rather than `ko`, which used to be the case formerly.